### PR TITLE
Add Barracuda and Libraesva providers

### DIFF
--- a/mxsniff/providers.py
+++ b/mxsniff/providers.py
@@ -63,6 +63,11 @@ providers = {
         ],
         'title': "AOL",
         },
+    'barracuda': {'mx': [
+        '*.*.*.*.barracudanetworks.com',
+        ],
+        'title': "Barracuda Networks",
+        },
     'carrierzone': {'mx': [
         '*.carrierzone.com',
         ]},
@@ -218,6 +223,9 @@ providers = {
         ]},
     'lfchosting': {'mx': [
         '*.loosefoot.com',
+        ]},
+    'libraesva': {'mx': [
+        '*.esvacloud.com',
         ]},
     'liquidnet': {'mx': [
         '*.supremebox.com',


### PR DESCRIPTION
I added two new providers to the providers.py file, they both offer cloud email security gateways to handle incoming email messages.